### PR TITLE
improvement(release): use a real bot, rather than github-actions

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -29,4 +29,4 @@ jobs:
         uses: overlayed-app/action-element-snapshot@v7.0.2
         with:
           source_url: https://cdn.jsdelivr.net/gh/overlayed-app/remote-overlay-test@1.1.0/index.js
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_BOT_AUTOMATION_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           git config --global user.name overlayed-app-bot
           git config --global user.email bot@overlayed.app
           git config --global credential.helper store
-          echo https://overlayed-app-bot:${{ secrets.GITHUB_TOKEN }}@github.com > ~/.git-credentials
+          echo https://overlayed-app-bot:${{ secrets.GH_BOT_AUTOMATION_TOKEN }}@github.com > ~/.git-credentials
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Per
https://github.community/t5/GitHub-Actions/Allowing-github-actions-bot-to-push-to-protected-branch/td-p/34367
we cannot leverage our release pattern on protected branches easily without a real user context. As
such, we've created a bot user on gh, and this switch credentials to use that account for
automation.